### PR TITLE
refactor: Renomeia o campo 'registroCmed' para 'id'

### DIFF
--- a/src/main/java/com/medicamentos/preco_maximo_consumidor_medicamentos_api/dto/MedicamentoAutocompleteDTO.java
+++ b/src/main/java/com/medicamentos/preco_maximo_consumidor_medicamentos_api/dto/MedicamentoAutocompleteDTO.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MedicamentoAutocompleteDTO {
 
-    private String registroCmed;
+    private String id;
     private String produto;
     private String principioAtivo;
     private String apresentacao;

--- a/src/main/java/com/medicamentos/preco_maximo_consumidor_medicamentos_api/model/search/Medicamento.java
+++ b/src/main/java/com/medicamentos/preco_maximo_consumidor_medicamentos_api/model/search/Medicamento.java
@@ -15,11 +15,10 @@ import org.springframework.data.elasticsearch.annotations.InnerField;
 public class Medicamento {
 
     @Id
-    @Field(name = "REGISTRO_CMED", type = FieldType.Keyword)
-    private String registroCmed;
+    private String id;
 
     @MultiField(
-            mainField = @Field(name = "PRODUTO", type = FieldType.Text, analyzer = "brazilian"), // <-- CORREÇÃO APLICADA
+            mainField = @Field(name = "PRODUTO", type = FieldType.Text, analyzer = "brazilian"),
             otherFields = {
                     @InnerField(suffix = "suggest", type = FieldType.Search_As_You_Type)
             }
@@ -27,7 +26,7 @@ public class Medicamento {
     private String produto;
 
     @MultiField(
-            mainField = @Field(name = "PRINCIPIO_ATIVO", type = FieldType.Text, analyzer = "brazilian"), // <-- CORREÇÃO APLICADA
+            mainField = @Field(name = "PRINCIPIO_ATIVO", type = FieldType.Text, analyzer = "brazilian"),
             otherFields = {
                     @InnerField(suffix = "suggest", type = FieldType.Search_As_You_Type)
             }
@@ -35,7 +34,7 @@ public class Medicamento {
     private String principioAtivo;
 
     @MultiField(
-            mainField = @Field(name = "APRESENTACAO", type = FieldType.Text, analyzer = "brazilian"), // <-- CORREÇÃO APLICADA
+            mainField = @Field(name = "APRESENTACAO", type = FieldType.Text, analyzer = "brazilian"),
             otherFields = {
                     @InnerField(suffix = "suggest", type = FieldType.Search_As_You_Type)
             }
@@ -43,7 +42,7 @@ public class Medicamento {
     private String apresentacao;
 
     @MultiField(
-            mainField = @Field(name = "LABORATORIO", type = FieldType.Text, analyzer = "brazilian"), // <-- CORREÇÃO APLICADA
+            mainField = @Field(name = "LABORATORIO", type = FieldType.Text, analyzer = "brazilian"),
             otherFields = {
                     @InnerField(suffix = "suggest", type = FieldType.Search_As_You_Type)
             }

--- a/src/main/java/com/medicamentos/preco_maximo_consumidor_medicamentos_api/service/impl/MedicamentoAutocompleteServiceImpl.java
+++ b/src/main/java/com/medicamentos/preco_maximo_consumidor_medicamentos_api/service/impl/MedicamentoAutocompleteServiceImpl.java
@@ -31,7 +31,7 @@ public class MedicamentoAutocompleteServiceImpl implements MedicamentoAutocomple
      */
     private MedicamentoAutocompleteDTO convertToAutocompleteDTO(Medicamento medicamento) {
         return new MedicamentoAutocompleteDTO(
-                medicamento.getRegistroCmed(),
+                medicamento.getId(),
                 medicamento.getProduto(),
                 medicamento.getPrincipioAtivo(),
                 medicamento.getApresentacao(),


### PR DESCRIPTION
- Atualiza o campo de identificação na entidade `Medicamento` e no DTO `MedicamentoAutocompleteDTO` para usar um nome mais genérico e padrão.
- Ajusta o serviço de autocompletar para refletir a mudança no nome do campo.